### PR TITLE
Do not discard textureless brushes if they belong to a trigger entity

### DIFF
--- a/HalfLife.UnifiedSdk.MapDecompiler/TreeDecompilation/TreeDecompiler.BSPToMap.cs
+++ b/HalfLife.UnifiedSdk.MapDecompiler/TreeDecompilation/TreeDecompiler.BSPToMap.cs
@@ -27,10 +27,13 @@ namespace HalfLife.UnifiedSdk.MapDecompiler.TreeDecompilation
 
             if (besttexinfo == TexInfoNode)
             {
-                // TODO: maybe add a clip texture to it and keep the brush
-                brush.Sides.Clear();
-                ++_numClipBrushes;
-                return;
+                // Allow textureless brushes to exist if the entity is a trigger or a func_nogrenades
+                if (!entity.Entity.ClassName.StartsWith("trigger_") && !entity.Entity.ClassName.StartsWith("func_nogrenades")) {
+                    // TODO: maybe add a clip texture to it and keep the brush
+                    brush.Sides.Clear();
+                    ++_numClipBrushes;
+                    return;
+                }
             }
 
             //set the texinfo for all the brush sides without texture
@@ -67,7 +70,17 @@ namespace HalfLife.UnifiedSdk.MapDecompiler.TreeDecompilation
 
             var mapbrush = BSPBrushToMap(decompiledBrush.Brush, origin);
 
-            entity.Entity.Children.Add(mapbrush);
+            // If this mapbrush was linked to a trigger in goldsrc,
+            // make sure to give it the trigger texture!!
+            if (entity.Entity.ClassName.StartsWith("trigger_") || entity.Entity.ClassName.StartsWith("func_nogrenades"))
+            {
+                foreach (var face in mapbrush.Faces)
+                {
+                    face.TextureName = "tools/toolstrigger";
+                }
+            }
+
+             entity.Entity.Children.Add(mapbrush);
         }
 
         /// <summary>

--- a/HalfLife.UnifiedSdk.MapDecompiler/TreeDecompilation/TreeDecompiler.cs
+++ b/HalfLife.UnifiedSdk.MapDecompiler/TreeDecompilation/TreeDecompiler.cs
@@ -308,6 +308,11 @@ namespace HalfLife.UnifiedSdk.MapDecompiler.TreeDecompilation
                 AddOriginBrush(entity, origin);
             }
 
+            if (entity.Entity.ClassName == "trigger_teleport" && origin == Vector3.Zero)
+            {
+                AddOriginBrush(entity, origin);
+            }
+
             if (modelNumber == 0)
             {
                 _logger.Information("{Count} brushes", brushlist.Count);


### PR DESCRIPTION
This fixes the reconstruction of trigger entities if they referred to a model for their geometry. 

See: conc_fly