### PR TITLE
Fix double 'origin' compile error.

### DIFF
--- a/HalfLife.UnifiedSdk.MapDecompiler/FaceToBrushDecompilation/FaceToBrushDecompiler.cs
+++ b/HalfLife.UnifiedSdk.MapDecompiler/FaceToBrushDecompilation/FaceToBrushDecompiler.cs
@@ -124,6 +124,10 @@ namespace HalfLife.UnifiedSdk.MapDecompiler.FaceToBrushDecompilation
 
             if (_options.AlwaysGenerateOriginBrushes || origin != Vector3.Zero)
             {
+                if (origin != Vector3.Zero)
+                {
+                    entity.SortedProperties.RemoveAll(item => item.Key.Equals("origin"));
+                }
                 entity.Children.Add(CreateOriginBrush(origin));
                 ++brushCount;
             }


### PR DESCRIPTION
**HLCSG:**
```
Entering cs_assault.map
Error: Entity 11, Brush 6: Only one ORIGIN brush allowed.
```
